### PR TITLE
User orders in profile #40

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,6 +28,10 @@ class ApplicationController < ActionController::Base
     render :file => './public/404.html', status: 404 unless admin_user?
   end
 
+  def require_regular_user
+    render :file => './public/404.html', status: 404 unless regular_user?
+  end
+  
   def set_cart
     @cart ||= Cart.new(session[:cart])
   end

--- a/app/controllers/users/orders_controller.rb
+++ b/app/controllers/users/orders_controller.rb
@@ -1,7 +1,6 @@
 class Users::OrdersController < ApplicationController
+  before_action :require_regular_user
   def index
-    unless regular_user?
-      render :file => './public/404.html', status: 404
-    end
+    @orders = current_user.orders
   end
 end

--- a/app/controllers/users/orders_controller.rb
+++ b/app/controllers/users/orders_controller.rb
@@ -3,4 +3,8 @@ class Users::OrdersController < ApplicationController
   def index
     @orders = current_user.orders
   end
+
+  def show
+    @order = Order.find(params[:id])
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,4 +6,8 @@ class Item < ApplicationRecord
   def order_quantity(order_id)
     OrderItem.find_by(order_id: order_id).quantity
   end
+
+  def quantity_price(order_id)
+    OrderItem.find_by(order_id: order_id).current_price
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,4 +2,8 @@ class Item < ApplicationRecord
   belongs_to :user
   has_many :order_items
   has_many :orders, through: :order_items
+
+  def order_quantity(order_id)
+    OrderItem.find_by(order_id: order_id).quantity
+  end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -5,4 +5,8 @@ class Order < ApplicationRecord
   has_many :items, through: :order_items
 
   enum status: ['pending', 'fufilled', 'cancelled']
+
+  def total_item_quantity
+    order_items.sum(:quantity)
+  end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -9,4 +9,8 @@ class Order < ApplicationRecord
   def total_item_quantity
     order_items.sum(:quantity)
   end
+
+  def total_item_price
+    order_items.sum(:current_price)
+  end
 end

--- a/app/views/users/orders/index.html.erb
+++ b/app/views/users/orders/index.html.erb
@@ -1,6 +1,6 @@
 <% @orders.each do |o| %>
 <section id="order-<%=o.id%>">
-  <p><%= link_to "ID: #{o.id}" %></p>
+  <p><%= link_to "ID: #{o.id}", profile_order_path(o.id) %></p>
   <p>Order Placed: <%= o.created_at %></p>
   <p>Last Updated: <%= o.updated_at %></p>
   <p>Current Status: <%= o.status %></p>

--- a/app/views/users/orders/index.html.erb
+++ b/app/views/users/orders/index.html.erb
@@ -1,0 +1,10 @@
+<% @orders.each do |o| %>
+<section id="order-<%=o.id%>">
+  <p><%= link_to "ID: #{o.id}" %></p>
+  <p>Order Placed: <%= o.created_at %></p>
+  <p>Last Updated: <%= o.updated_at %></p>
+  <p>Current Status: <%= o.status %></p>
+  <p>Total Items: <%= o.total_item_quantity %></p>
+  <p>Grand Total: <%= o.total_item_price %></p>
+</section>
+<% end %>

--- a/app/views/users/orders/show.html.erb
+++ b/app/views/users/orders/show.html.erb
@@ -1,0 +1,18 @@
+<section>
+<p>ID: <%= @order.id %></p>
+<p>Order Placed: <%= @order.created_at %></p>
+<p>Last Updated: <%= @order.updated_at %></p>
+<p>Current Status: <%= @order.status %></p>
+<% @order.items.each do |item| %>
+<div class="item-<%= item.id %>">
+  <p>Name: <%= item.name %> </p>
+  <p>Description: <%= item.description %></p>
+  <p>Quantity: <%= item.order_quantity(@order.id) %></p>
+  <p>Price: <%= item.price %> </p>
+  <p>Sub Total: <%= item.quantity_price(@order.id) %></p>
+  <%= item.thumbnail %>
+</div>
+<% end %>
+<p>Total Items: <%= @order.total_item_quantity %></p>
+<p>Grand Total: <%= @order.total_item_price %></p>
+</section>

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -7,5 +7,5 @@
   <p>Zip Code: <%= current_user.zip_code %> </p>
   <p>Email: <%= current_user.email %> </p>
   <p><%= link_to "Edit Profile", edit_profile_path %></p>
-  <p><%= link_to 'View Orders' %></p>
+  <p><%= link_to 'View Orders', profile_orders_path%></p>
 </section>

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -7,5 +7,5 @@
   <p>Zip Code: <%= current_user.zip_code %> </p>
   <p>Email: <%= current_user.email %> </p>
   <p><%= link_to "Edit Profile", edit_profile_path %></p>
-  <p><%= link_to "See #{current_user.username}'s orders"%></p>
+  <p><%= link_to 'View Orders' %></p>
 </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   get '/profile', to: 'users#profile', as: 'profile'
   put '/profile', to: 'users#update'
   get '/profile/orders', to: 'users/orders#index', as: 'profile_orders'
+  get '/profile/orders/:id', to: 'users/orders#show', as: 'profile_order'
 
   get '/profile/edit', to: 'users#edit', as: 'edit_profile'
 

--- a/spec/features/a_user_can_see_their_orders_in_showpage_spec.rb
+++ b/spec/features/a_user_can_see_their_orders_in_showpage_spec.rb
@@ -10,10 +10,21 @@ RSpec.describe 'as a registered user', type: :feature do
       visit profile_path
 
       expect(current_path).to eq(profile_path)
-      expect(page).to have_link('View Orders')
+      within '.user-info' do
+        expect(page).to have_link('View Orders')
+      end
     end
 
-    it 'in the nav a user sees a link to their orders page'
+    it 'in the nav a user sees a link to their orders page' do
+      user = User.create(username: 'bob', street: "1234", city: "bob", state: "bobby", zip_code: 12345, email: "12345@54321", password: "password", role: 0, enabled: 0)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      visit profile_path
+
+      within '.navbar' do
+        expect(page).to have_link("Orders")
+      end
+    end
 
   end
 

--- a/spec/features/a_user_can_see_their_orders_in_showpage_spec.rb
+++ b/spec/features/a_user_can_see_their_orders_in_showpage_spec.rb
@@ -26,6 +26,38 @@ RSpec.describe 'as a registered user', type: :feature do
       end
     end
 
+    it 'lets a user see their orders page' do
+      user = User.create(username: 'bob', street: "1234", city: "bob", state: "bobby", zip_code: 12345, email: "12345@54321", password: "password", role: 0, enabled: 0)
+      merchant = User.create(username: 'bob', street: "1234", city: "bob", state: "bobby", zip_code: 12345, email: "12@54321", password: "password", role: 1, enabled: 0)
+      item_1 = Item.create(name: 'meh', description: "haha", quantity: 12, price: 2.5, thumbnail: "steve.jpg", user_id: merchant.id)
+      item_2 = Item.create(name: 'vfjkdnj', description: "fjndkjknk", quantity: 12, price: 2.5, thumbnail: "steve.jpg", user_id: merchant.id)
+      item_3 = Item.create(name: 'fvijodv', description: "oreijvioe", quantity: 12, price: 2.5, thumbnail: "steve.jpg", user_id: merchant.id)
+      order_1 = Order.create(user_id: user.id)
+      order_2 = Order.create(user_id: user.id)
+      Orderitem.create(item_id: item_1.id, order_id: order_1.id, fullfilled: 0, current_price: 5.0, quantity: 2)
+      Orderitem.create(item_id: item_2.id, order_id: order_1.id, fullfilled: 0, current_price: 7.5, quantity: 3)
+      Orderitem.create(item_id: item_3.id, order_id: order_2.id, fullfilled: 0, current_price: 10.0, quantity: 4)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      visit profile_path
+      click_link 'View Orders'
+
+      expect(current_path).to eq(profile_orders_path)
+
+      within "#order-#{order_1.id}" do
+        expect(page).to have_link("ID: #{order_1.id}")
+        expect(page).to have_link("Order Placed: #{order_1.created_at}")
+        expect(page).to have_link("Order updated: #{order_1.updated_at}")
+        expect(page).to have_link("Current Status: #{order_1.status}")
+        expect(page).to have_link("Total Items: #{order_1.total_item_quantity}")
+        expect(page).to have_link("Grand Total: #{order_1.total_item_price}")
+      end
+      within "#order-#{order_2.id}" do
+        expect(page).to have_link("ID: #{order_2.id}")
+        expect(page).to have_link("Total Items: #{order_2.total_item_quantity}")
+        expect(page).to have_link("Grand Total: #{order_2.total_item_price}")
+      end
+    end
   end
 
 

--- a/spec/features/a_user_can_see_their_orders_in_showpage_spec.rb
+++ b/spec/features/a_user_can_see_their_orders_in_showpage_spec.rb
@@ -34,9 +34,9 @@ RSpec.describe 'as a registered user', type: :feature do
       item_3 = Item.create(name: 'fvijodv', description: "oreijvioe", quantity: 12, price: 2.5, thumbnail: "steve.jpg", user_id: merchant.id)
       order_1 = Order.create(user_id: user.id)
       order_2 = Order.create(user_id: user.id)
-      Orderitem.create(item_id: item_1.id, order_id: order_1.id, fullfilled: 0, current_price: 5.0, quantity: 2)
-      Orderitem.create(item_id: item_2.id, order_id: order_1.id, fullfilled: 0, current_price: 7.5, quantity: 3)
-      Orderitem.create(item_id: item_3.id, order_id: order_2.id, fullfilled: 0, current_price: 10.0, quantity: 4)
+      OrderItem.create(item_id: item_1.id, order_id: order_1.id, fulfilled: 0, current_price: 5.0, quantity: 2)
+      OrderItem.create(item_id: item_2.id, order_id: order_1.id, fulfilled: 0, current_price: 7.5, quantity: 3)
+      OrderItem.create(item_id: item_3.id, order_id: order_2.id, fulfilled: 0, current_price: 10.0, quantity: 4)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
       visit profile_path
@@ -47,7 +47,7 @@ RSpec.describe 'as a registered user', type: :feature do
       within "#order-#{order_1.id}" do
         expect(page).to have_link("ID: #{order_1.id}")
         expect(page).to have_link("Order Placed: #{order_1.created_at}")
-        expect(page).to have_link("Order updated: #{order_1.updated_at}")
+        expect(page).to have_link("Last Updated: #{order_1.updated_at}")
         expect(page).to have_link("Current Status: #{order_1.status}")
         expect(page).to have_link("Total Items: #{order_1.total_item_quantity}")
         expect(page).to have_link("Grand Total: #{order_1.total_item_price}")

--- a/spec/features/a_user_can_see_their_orders_in_showpage_spec.rb
+++ b/spec/features/a_user_can_see_their_orders_in_showpage_spec.rb
@@ -46,16 +46,16 @@ RSpec.describe 'as a registered user', type: :feature do
 
       within "#order-#{order_1.id}" do
         expect(page).to have_link("ID: #{order_1.id}")
-        expect(page).to have_link("Order Placed: #{order_1.created_at}")
-        expect(page).to have_link("Last Updated: #{order_1.updated_at}")
-        expect(page).to have_link("Current Status: #{order_1.status}")
-        expect(page).to have_link("Total Items: #{order_1.total_item_quantity}")
-        expect(page).to have_link("Grand Total: #{order_1.total_item_price}")
+        expect(page).to have_content("Order Placed: #{order_1.created_at}")
+        expect(page).to have_content("Last Updated: #{order_1.updated_at}")
+        expect(page).to have_content("Current Status: #{order_1.status}")
+        expect(page).to have_content("Total Items: #{order_1.total_item_quantity}")
+        expect(page).to have_content("Grand Total: #{order_1.total_item_price}")
       end
       within "#order-#{order_2.id}" do
         expect(page).to have_link("ID: #{order_2.id}")
-        expect(page).to have_link("Total Items: #{order_2.total_item_quantity}")
-        expect(page).to have_link("Grand Total: #{order_2.total_item_price}")
+        expect(page).to have_content("Total Items: #{order_2.total_item_quantity}")
+        expect(page).to have_content("Grand Total: #{order_2.total_item_price}")
       end
     end
   end

--- a/spec/features/a_user_can_see_their_orders_in_showpage_spec.rb
+++ b/spec/features/a_user_can_see_their_orders_in_showpage_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+
+RSpec.describe 'as a registered user', type: :feature do
+  describe 'when a user is logged in' do
+    it 'in their showpage they see an orders link' do
+      user = User.create(username: 'bob', street: "1234", city: "bob", state: "bobby", zip_code: 12345, email: "12345@54321", password: "password", role: 0, enabled: 0)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      visit profile_path
+
+      expect(current_path).to eq(profile_path)
+      expect(page).to have_link('View Orders')
+    end
+
+    it 'in the nav a user sees a link to their orders page'
+
+  end
+
+
+end

--- a/spec/features/user_order_show_spec.rb
+++ b/spec/features/user_order_show_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe 'As a registered user', type: :feature do
+
+  describe ' When a user visits an order show page' do
+    it 'Shows information about the order' do
+      user = User.create(username: 'bob', street: "1234", city: "bob", state: "bobby", zip_code: 12345, email: "12345@54321", password: "password", role: 0, enabled: 0)
+      merchant = User.create(username: 'bob', street: "1234", city: "bob", state: "bobby", zip_code: 12345, email: "12@54321", password: "password", role: 1, enabled: 0)
+      item_1 = Item.create(name: 'meh', description: "haha", quantity: 12, price: 2.5, thumbnail: "steve.jpg", user_id: merchant.id)
+      item_2 = Item.create(name: 'vfjkdnj', description: "fjndkjknk", quantity: 12, price: 2.5, thumbnail: "steve.jpg", user_id: merchant.id)
+      item_3 = Item.create(name: 'fvijodv', description: "oreijvioe", quantity: 12, price: 2.5, thumbnail: "steve.jpg", user_id: merchant.id)
+      order_1 = Order.create(user_id: user.id)
+      order_2 = Order.create(user_id: user.id)
+      order_item_1 = OrderItem.create(item_id: item_1.id, order_id: order_1.id, fulfilled: 0, current_price: 5.0, quantity: 2)
+      OrderItem.create(item_id: item_2.id, order_id: order_1.id, fulfilled: 0, current_price: 7.5, quantity: 3)
+      OrderItem.create(item_id: item_3.id, order_id: order_2.id, fulfilled: 0, current_price: 10.0, quantity: 4)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      visit profile_orders_path
+      click_link "ID: #{order_1.id}"
+
+      expect(current_path).to eq(profile_order_path(order_1))
+      expect(page).to have_content("ID: #{order_1.id}")
+      expect(page).to have_content("Order Placed: #{order_1.created_at}")
+      expect(page).to have_content("Last Updated: #{order_1.updated_at}")
+      expect(page).to have_content("Current Status: #{order_1.status}")
+      within ".item-#{item_1}" do
+        expect(page).to have_content("Name: #{item_1.name}")
+        expect(page).to have_content("Description: #{item_1.description}")
+        expect(page).to have_content("Quantity: #{order_item_1.quantity}")
+        expect(page).to have_content("Price: #{item_1.price}")
+        expect(page).to have_content("Sub Total: #{order_item_1.current_price}")
+        # expect(page).to xpath("thumbnail: #{item_1.thumbnail}")
+      end
+      expect(page).to have_content("Total Items: #{order_1.total_item_quantity}")
+      expect(page).to have_content("Grand Total: #{order_1.total_item_price}")
+    end
+  end
+end

--- a/spec/features/user_order_show_spec.rb
+++ b/spec/features/user_order_show_spec.rb
@@ -17,14 +17,16 @@ RSpec.describe 'As a registered user', type: :feature do
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
       visit profile_orders_path
+      # save_and_open_page
       click_link "ID: #{order_1.id}"
-
+      # save_and_open_page
       expect(current_path).to eq(profile_order_path(order_1))
       expect(page).to have_content("ID: #{order_1.id}")
       expect(page).to have_content("Order Placed: #{order_1.created_at}")
       expect(page).to have_content("Last Updated: #{order_1.updated_at}")
-      expect(page).to have_content("Current Status: #{order_1.status}")
-      within ".item-#{item_1}" do
+      expect(page).to have_content("Current Status: pending")
+
+      within ".item-#{item_1.id}" do
         expect(page).to have_content("Name: #{item_1.name}")
         expect(page).to have_content("Description: #{item_1.description}")
         expect(page).to have_content("Quantity: #{order_item_1.quantity}")

--- a/spec/features/visitor_naviogation_bar_spec.rb
+++ b/spec/features/visitor_naviogation_bar_spec.rb
@@ -3,9 +3,9 @@ require 'rails_helper'
 RSpec.describe 'navigation', type: :feature do
 
   it 'as a visitor' do
-    user = User.create(username: 'bob', street: "1234", city: "bob", state: "bobby", zip_code: 12345, email: "12345@54321", password: "password", role: 0, enabled: 0)
-    merchant = User.create(username: 'merch', street: "1234", city: "bob", state: "bobby", zip_code: 12345, email: "12345@merch", password: "password", role: 1, enabled: 0)
-    admin = User.create(username: 'admin', street: "1234", city: "bob", state: "bobby", zip_code: 12345, email: "12345@admin", password: "password", role: 2, enabled: 0)
+    # user = User.create(username: 'bob', street: "1234", city: "bob", state: "bobby", zip_code: 12345, email: "12345@54321", password: "password", role: 0, enabled: 0)
+    # merchant = User.create(username: 'merch', street: "1234", city: "bob", state: "bobby", zip_code: 12345, email: "12345@merch", password: "password", role: 1, enabled: 0)
+    # admin = User.create(username: 'admin', street: "1234", city: "bob", state: "bobby", zip_code: 12345, email: "12345@admin", password: "password", role: 2, enabled: 0)
 
     visit items_path
     click_link "Home"
@@ -24,6 +24,7 @@ RSpec.describe 'navigation', type: :feature do
 
     visit new_user_path
     click_link "Log In"
+
     expect(current_path).to eq(login_path)
 
     expect(page).to_not have_link('Profile')

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -29,7 +29,22 @@ RSpec.describe Item, type: :model do
       end
     end
     describe '.quantity_price' do
-      it 'should show the total price of that item in order'
+      it 'should show the total price of that item in order' do
+        user = User.create(username: 'bob', street: "1234", city: "bob", state: "bobby", zip_code: 12345, email: "12345@54321", password: "password", role: 0, enabled: 0)
+        merchant = User.create(username: 'bob', street: "1234", city: "bob", state: "bobby", zip_code: 12345, email: "12@54321", password: "password", role: 1, enabled: 0)
+        item_1 = Item.create(name: 'meh', description: "haha", quantity: 12, price: 2.5, thumbnail: "steve.jpg", user_id: merchant.id)
+        item_2 = Item.create(name: 'vfjkdnj', description: "fjndkjknk", quantity: 12, price: 2.5, thumbnail: "steve.jpg", user_id: merchant.id)
+        item_3 = Item.create(name: 'fvijodv', description: "oreijvioe", quantity: 12, price: 2.5, thumbnail: "steve.jpg", user_id: merchant.id)
+        order_1 = Order.create(user_id: user.id)
+        order_2 = Order.create(user_id: user.id)
+        order_item_1 = OrderItem.create(item_id: item_1.id, order_id: order_1.id, fulfilled: 0, current_price: 5.0, quantity: 2)
+        OrderItem.create(item_id: item_2.id, order_id: order_1.id, fulfilled: 0, current_price: 7.5, quantity: 3)
+        OrderItem.create(item_id: item_3.id, order_id: order_2.id, fulfilled: 0, current_price: 10.0, quantity: 4)
+
+        item_total_price = item_1.quantity_price(order_1.id)
+
+        expect(item_total_price).to eq(5.0)
+      end
     end
 
   end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -8,4 +8,29 @@ RSpec.describe Item, type: :model do
   describe 'realationships' do
     it {should belong_to :user}
   end
+
+  describe 'instance methods' do
+    describe '.order_quantity' do
+      it 'should show the quantity of items in an order' do
+        user = User.create(username: 'bob', street: "1234", city: "bob", state: "bobby", zip_code: 12345, email: "12345@54321", password: "password", role: 0, enabled: 0)
+        merchant = User.create(username: 'bob', street: "1234", city: "bob", state: "bobby", zip_code: 12345, email: "12@54321", password: "password", role: 1, enabled: 0)
+        item_1 = Item.create(name: 'meh', description: "haha", quantity: 12, price: 2.5, thumbnail: "steve.jpg", user_id: merchant.id)
+        item_2 = Item.create(name: 'vfjkdnj', description: "fjndkjknk", quantity: 12, price: 2.5, thumbnail: "steve.jpg", user_id: merchant.id)
+        item_3 = Item.create(name: 'fvijodv', description: "oreijvioe", quantity: 12, price: 2.5, thumbnail: "steve.jpg", user_id: merchant.id)
+        order_1 = Order.create(user_id: user.id)
+        order_2 = Order.create(user_id: user.id)
+        order_item_1 = OrderItem.create(item_id: item_1.id, order_id: order_1.id, fulfilled: 0, current_price: 5.0, quantity: 2)
+        OrderItem.create(item_id: item_2.id, order_id: order_1.id, fulfilled: 0, current_price: 7.5, quantity: 3)
+        OrderItem.create(item_id: item_3.id, order_id: order_2.id, fulfilled: 0, current_price: 10.0, quantity: 4)
+
+        item_count = item_1.order_quantity(order_1.id)
+
+        expect(item_count).to eq(2)
+      end
+    end
+    describe '.quantity_price' do
+      it 'should show the total price of that item in order'
+    end
+
+  end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Order, type: :model do
       it 'should total the number of items in an order' do
         user = User.create(username: 'bob', street: "1234", city: "bob", state: "bobby", zip_code: 12345, email: "12345@54321", password: "password", role: 0, enabled: 0)
         merchant = User.create(username: 'bob', street: "1234", city: "bob", state: "bobby", zip_code: 12345, email: "12@54321", password: "password", role: 1, enabled: 0)
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
         item_1 = Item.create(name: 'meh', description: "haha", quantity: 12, price: 2.5, thumbnail: "steve.jpg", user_id: merchant.id)
         item_2 = Item.create(name: 'vfjkdnj', description: "fjndkjknk", quantity: 12, price: 2.5, thumbnail: "steve.jpg", user_id: merchant.id)
         order = Order.create(user_id: user.id)

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -8,4 +8,28 @@ RSpec.describe Order, type: :model do
   describe 'realationships' do
     it {should belong_to :user}
   end
+
+  describe 'instance methods' do
+    describe '.total_item_quantity' do
+      it 'should total the number of items in an order' do
+        user = User.create(username: 'bob', street: "1234", city: "bob", state: "bobby", zip_code: 12345, email: "12345@54321", password: "password", role: 0, enabled: 0)
+        merchant = User.create(username: 'bob', street: "1234", city: "bob", state: "bobby", zip_code: 12345, email: "12@54321", password: "password", role: 1, enabled: 0)
+        item_1 = Item.create(name: 'meh', description: "haha", quantity: 12, price: 2.5, thumbnail: "steve.jpg", user_id: merchant.id)
+        item_2 = Item.create(name: 'vfjkdnj', description: "fjndkjknk", quantity: 12, price: 2.5, thumbnail: "steve.jpg", user_id: merchant.id)
+        order = Order.create(user_id: user.id)
+        OrderItem.create(item_id: item_1.id, order_id: order.id, fulfilled: 0, current_price: 5.0, quantity: 2)
+        OrderItem.create(item_id: item_2.id, order_id: order.id, fulfilled: 0, current_price: 7.5, quantity: 3)
+
+        total_items = order.total_item_quantity
+
+        expect(total_items).to eq(5)
+      end
+    end
+
+    describe '.total_item_price' do
+      it 'should total the price of items in an order'
+    end
+
+
+  end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -28,7 +28,20 @@ RSpec.describe Order, type: :model do
     end
 
     describe '.total_item_price' do
-      it 'should total the price of items in an order'
+      it 'should total the price of items in an order' do
+        user = User.create(username: 'bob', street: "1234", city: "bob", state: "bobby", zip_code: 12345, email: "12345@54321", password: "password", role: 0, enabled: 0)
+        merchant = User.create(username: 'bob', street: "1234", city: "bob", state: "bobby", zip_code: 12345, email: "12@54321", password: "password", role: 1, enabled: 0)
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+        item_1 = Item.create(name: 'meh', description: "haha", quantity: 12, price: 2.5, thumbnail: "steve.jpg", user_id: merchant.id)
+        item_2 = Item.create(name: 'vfjkdnj', description: "fjndkjknk", quantity: 12, price: 2.5, thumbnail: "steve.jpg", user_id: merchant.id)
+        order = Order.create(user_id: user.id)
+        OrderItem.create(item_id: item_1.id, order_id: order.id, fulfilled: 0, current_price: 5.0, quantity: 2)
+        OrderItem.create(item_id: item_2.id, order_id: order.id, fulfilled: 0, current_price: 7.5, quantity: 3)
+
+        total_price = order.total_item_price
+
+        expect(total_price).to eq(12.5)
+      end
     end
 
 


### PR DESCRIPTION
This adds the order index and order show pages for a user.

In the index it shows all orders for that user and with a link to the show page.

the show page shows a more in-depth breakdown with each items individual price, the quantity and total price per group of items, as well as the grand total.

This completes user stories 32, 33, and 34. 